### PR TITLE
Removing *.o files on Windows build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rdisop
 Title: Decomposition of Isotopic Patterns
-Version: 1.43.4
-Date: 2019-04-14
+Version: 1.43.4-1
+Date: 2019-04-18
 Author: Anton Pervukhin <apervukh@minet.uni-jena.de>, Steffen Neumann <sneumann@ipb-halle.de> 
 Maintainer: Steffen Neumann <sneumann@ipb-halle.de>
 Description: Identification of metabolites using high precision mass
@@ -17,4 +17,4 @@ License: GPL-2
 URL: https://github.com/sneumann/Rdisop
 BugReports: https://github.com/sneumann/Rdisop/issues/new
 biocViews: ImmunoOncology, MassSpectrometry, Metabolomics
-Packaged: 2012-02-16 14:03:45.877398 UTC; edd
+

--- a/cleanup.win
+++ b/cleanup.win
@@ -1,0 +1,2 @@
+find ./src/ -type f -name '*.o' -exec rm {} \;
+rm -f src/*.dll src/Makedeps src/*_res.*


### PR DESCRIPTION
Related to #13.  Can't promise this is a complete solution, but explicitly making sure the object files that the BioC builder is complaining about are deleted once the package is built seems to fix the problem for me.

Tested on Windows 10 with Rtools 3.5 and R-3.6.0.beta via:

```sh
git clone https://github.com/grimbough/Rdisop
R CMD build --keep-empty-dirs --no-resave-data Rdisop
rm -rf Rdisop.buildbin-libdir && mkdir Rdisop.buildbin-libdir && R CMD INSTALL --merge-multiarch --build --library=Rdisop.buildbin-libdir Rdisop_1.43.4-1.tar.gz
```

Happy to run more tests if this introduces something horrible.