### PR TITLE
Addressing issue with minElements in decomposeMass()/decomposeIsotopes()

### DIFF
--- a/inst/unitTests/runit.minmaxElements.R
+++ b/inst/unitTests/runit.minmaxElements.R
@@ -1,0 +1,104 @@
+
+#default settings for minElements and maxElements
+test.minmaxElements1 <- function() {
+
+  elem <-  initializeElements(c("C","H","N","O","P"))
+  testmass <- 269.2431
+  
+  res <- decomposeMass(testmass, ppm = 5, mzabs = 0, elements = elem)   
+  
+  checkEquals(res$formula[order(abs(res$exactmass - testmass))],c("C6H34N6O3P",
+                                                                        "C2H37N7O3P2",
+                                                                        "C3H43O8P2",
+                                                                        "C10H31N5O3",
+                                                                        "C3H48NOP5",
+                                                                        "C12H33N2O4",
+                                                                        "C7H45OP4",
+                                                                        "CH41N3O7P2",
+                                                                        "H35N10O2P2",
+                                                                        "C8H36N3O4P"))
+}
+
+#must filter out formulas that do not contain C
+test.minmaxElements2 <- function() {
+  
+  elem <-  initializeElements(c("C","H","N","O","P"))
+  testmass <- 269.2431
+  
+  res <- decomposeMass(testmass, ppm = 5, mzabs = 0, elements = elem, minElements = "C1")   
+  
+  checkEquals(res$formula[order(abs(res$exactmass - testmass))],c("C6H34N6O3P",
+                                                                        "C2H37N7O3P2",
+                                                                        "C3H43O8P2",
+                                                                        "C10H31N5O3",
+                                                                        "C3H48NOP5",
+                                                                        "C12H33N2O4",
+                                                                        "C7H45OP4",
+                                                                        "CH41N3O7P2",
+                                                                        "C8H36N3O4P"))
+}
+
+#set maxElements
+test.minmaxElements3 <- function() {
+  
+  elem <-  initializeElements(c("C","H","N","O","P"))
+  testmass <- 269.2431
+  
+  res <- decomposeMass(testmass, ppm = 5,  mzabs = 0, elements = elem, minElements = "C1", maxElements = "C6")   
+  
+  checkEquals(res$formula[order(abs(res$exactmass - testmass))],c("C6H34N6O3P",
+                                                                       "C2H37N7O3P2",
+                                                                       "C3H43O8P2",
+                                                                       "C3H48NOP5",
+                                                                       "CH41N3O7P2"))
+}
+
+
+#equal minElements and maxElements
+test.minmaxElements4 <- function() {
+  
+  elem <-  initializeElements(c("C","H","N","O","P"))
+  testmass <- 269.2431
+  
+  res <- decomposeMass(testmass, ppm = 5,  mzabs = 0, elements = elem, minElements = "C6", maxElements = "C6")   
+  
+  checkEquals(res$formula[order(abs(res$exactmass - testmass))],c("C6H34N6O3P"
+                                                                 ))
+}
+
+#maxElements > minElements
+test.minmaxElements5 <- function() {
+  
+  elem <-  initializeElements(c("C","H","N","O","P"))
+  testmass <- 269.2431
+  
+  res <- decomposeMass(testmass, ppm = 5,  mzabs = 0, elements = elem, minElements = "C6", maxElements = "C5")   
+  
+  checkTrue(is.null(res))
+}
+
+
+#Zeros in maxElements are ignored and do not cause an error
+test.minmaxElements6 <- function() {
+  
+  elem <-  initializeElements(c("C","H","N","O","P"))
+  testmass <- 269.2431
+  
+  res <- decomposeMass(testmass, ppm = 5,  mzabs = 0, elements = elem, minElements = "C6", maxElements = "P0")   
+  
+  checkEquals(res$formula[order(abs(res$exactmass - testmass))],c("C6H34N6O3P", "C10H31N5O3", "C12H33N2O4", "C7H45OP4", "C8H36N3O4P"))
+}
+
+#more complex exammple:
+test.minmaxElements6 <- function() {
+  
+  elem <- initializeCHNOPS()       
+  testmass <- 347.0630844422
+  
+  res <- decomposeMass(testmass, ppm = 5,  mzabs = 0, elements = elem, minElements = "C10O6PN", maxElements = "O10P1S3")   
+  
+  checkEquals(res$formula[order(abs(res$exactmass - testmass))],c("C10H14N5O7P",  "C10H22NO6PS2", "C12H16N2O8P"))
+}
+
+
+

--- a/inst/unitTests/runit.minmaxElements.R
+++ b/inst/unitTests/runit.minmaxElements.R
@@ -90,7 +90,7 @@ test.minmaxElements6 <- function() {
 }
 
 #more complex exammple:
-test.minmaxElements6 <- function() {
+test.minmaxElements7 <- function() {
   
   elem <- initializeCHNOPS()       
   testmass <- 347.0630844422

--- a/src/disop.cpp
+++ b/src/disop.cpp
@@ -119,22 +119,32 @@ bool isValidMyNitrogenRule(const ComposedElement& molecule, int z) {
 bool isWithinElementRange(const ComposedElement& molecule, const ComposedElement& minElements, const ComposedElement& maxElements) {
 // {{{
 
-  for (ComposedElement::container::const_iterator it = molecule.getElements().begin(); 
-       it != molecule.getElements().end(); ++it) {
-    
+//iterating over Elements present in minElements
+  for (ComposedElement::container::const_iterator it = minElements.getElements().begin();
+       it != minElements.getElements().end(); ++it) {
+
     int mincount = static_cast<int>(minElements.getElementAbundance((it->first).getName()));
-    int maxcount = static_cast<int>(maxElements.getElementAbundance((it->first).getName()));
 
     int count = static_cast<int>(molecule.getElementAbundance((it->first).getName()));
-      
+
       if (count < mincount) {
 	return false;
       }
 
-      // TODO: Fails e.g. for "C2N0" 
-      if (maxcount>0 && count > maxcount) {
-	return false;
-      }
+  }
+  
+  //must iterate over Elements present in molecule and ignore cases of Elements not defined in maxElements
+  for (ComposedElement::container::const_iterator it = maxElements.getElements().begin(); 
+       it != maxElements.getElements().end(); ++it) {
+    
+    int maxcount = static_cast<int>(maxElements.getElementAbundance((it->first).getName()));
+    
+    int count = static_cast<int>(molecule.getElementAbundance((it->first).getName()));
+    
+    // TODO: Fails e.g. for "C2N0" 
+    if (maxcount>0 && count > maxcount) {
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
Fixing issue as discussed in #6. 

Before:
```
> decomposeMass(347.0630844422, ppm = 5,  mzabs = 0, minElements = "C10O6PN", maxElements = "O10P1S3")$formula
 [1] "C10H14N5O7P"  "C14H11N4O7"   "C10H22NO6PS2" "C14H19O6S2"   "C16H13NO8"    "C10H138N4S"   "C23H11N2S"    "C12H16N2O8P"  "C19H14N3PS"   "C12H9N7O6" 
```

After:
```
> decomposeMass(347.0630844422, ppm = 5,  mzabs = 0, minElements = "C10O6PN", maxElements = "O10P1S3")$formula
[1] "C10H14N5O7P"  "C10H22NO6PS2" "C12H16N2O8P" 
```

Unit tests check if results are correctly applying element filters, and expected results were externally verified by running the same mass query on [chemcalc.org](http://www.chemcalc.org).