### PR TITLE
Small compilation fix

### DIFF
--- a/src/disop.cpp
+++ b/src/disop.cpp
@@ -682,7 +682,7 @@ SEXP  rlistScores(multimap<score_type, ComposedElement, greater<score_type> > sc
 	UNPROTECT(1); // SEXP isotopes
 
 	if(exceptionMesg != NULL) {
-	  Rf_error(exceptionMesg);
+	  Rf_error("%s", exceptionMesg);
 	}
 	
 	return(List::create(  _["formula"]  = formula,


### PR DESCRIPTION
Hello,

It seems Rdisop doesn't compile with recent gcc versions (e.g. from rocker Docker images). This small PR seems to fix it.