### PR TITLE
Fix for issue #33

### DIFF
--- a/src/imslib/src/ims/utils/distribution.cpp
+++ b/src/imslib/src/ims/utils/distribution.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <ims/utils/distribution.h>
 #include <algorithm>
+#include <Rcpp.h>
 
 namespace ims {
 
@@ -35,9 +36,12 @@ Distribution::Distribution(std::vector<double> dist): p(dist), size(p.size()) {
 * Get a random number.
 */
 size_t Distribution::getRand(){
-	size_t i = (size_t)( rand()/(RAND_MAX+1.0)*size );
-	double r = (double(rand())/RAND_MAX);
-
+    // 2024-11-18 rand() statements substituted by Rcpp equivalents
+	// size_t i = (size_t)( rand()/(RAND_MAX+1.0)*size );
+	// double r = (double(rand())/RAND_MAX);
+	size_t i = (size_t)( R::runif(0,0.999999)*size );
+    double r = (R::runif(0,1));
+    
 	if(p[i] < r){
 		return j[i];
 	}

--- a/src/imslib/tests/markovsequencegeneratortest.cpp
+++ b/src/imslib/tests/markovsequencegeneratortest.cpp
@@ -5,6 +5,8 @@
 
 #include <ims/markovsequencegenerator.h>
 
+#include <Rcpp.h>
+
 using namespace ims;
 
 class MarkovSequenceGeneratorTest : public CppUnit::TestFixture {
@@ -44,7 +46,9 @@ void MarkovSequenceGeneratorTest::testGetSequence() {
 	for(size_t i=0; i<alphabet.size(); i++){
 		std::vector<double> p;
 		for(size_t n=0; n<alphabet.size(); n++){
-			p.push_back((double(rand())/RAND_MAX));
+		    // 2024-11-18 rand() statements substituted by Rcpp equivalents
+			// p.push_back((double(rand())/RAND_MAX));
+			p.push_back(R::runif(0,1));
 		}
 		
 		double sum=0;


### PR DESCRIPTION
Fix for issue #33, substituting random number calls in a CRAN approved way.
The modifications in C Code are only there to avoid CRAN warnings on the RNG usage issue.
I don't think ChangeLog and new version number are required but you can add of course.