### PR TITLE
v1.67.6 fix for issue #5

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^README\.Rmd$
 ^\.github$
 ^data-raw$
+^build$

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2025-05-27 Jan Lisec <jan.lisec@bam.de>
+
+    * Rdisop-1.67.6
+    * parameter `elements` can now be specified using a character like 'CHNOPS' 
+      similar to the parameters `minElements` and `maxElements`
+    * fix for issue #5; implementing checks for parameters `minElements` and 
+      `maxElements` (both have default settings including element 'C' which 
+      caused an error when C was not included in the defined element list)
+    * implementing checks for parameter `elements` using internal function
+      `check_elements()`
+
 2025-01-22 Jan Lisec <jan.lisec@bam.de>
 
     * Rdisop-1.67.5

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rdisop
 Title: Decomposition of Isotopic Patterns
-Version: 1.67.5
-Date: 2025-01-21
+Version: 1.67.6
+Date: 2025-05-27
 Authors@R: 
     c(
         person("Anton", "Pervukhin", , "apervukh@minet.uni-jena.de", role = c("aut")),

--- a/R/decomposeIsotopes.R
+++ b/R/decomposeIsotopes.R
@@ -10,7 +10,11 @@
 #' @param intensities Absolute or relative intensities of the \code{masses} peaks.
 #' @param ppm Allowed deviation of hypotheses from given mass.
 #' @param mzabs Absolute deviation in Dalton (mzabs and ppm will be added).
-#' @param elements List of allowed chemical elements, defaults to CHNOPS. See \code{\link{initializeElements}}.
+#' @param elements List of allowed chemical elements, defaults to CHNOPS. 
+#'     See \code{\link{initializeElements}}. Can also be specified similar to
+#'     parameter `minElements` like a formula. 'CHNOPS' would define the elements
+#'     C, H, N, O, P and S. 'NA' would specify the element N and return a warning
+#'     regarding 'A' because this element is undefined in the PSE.
 #' @param filter NYI, will be a selection of DU, DBE and Nitrogen rules.
 #' @param z Charge z of m/z peaks for calculation of real mass, keep z=0 for auto-detection.
 #' @param maxisotopes Maximum number of isotopes shown in the resulting molecules.
@@ -59,25 +63,30 @@ decomposeIsotopes <- function(
 ) {
   
     # Use CHNOPS unless stated otherwise
-    if (!is.list(elements) || length(elements) == 0) { elements <- initializeCHNOPS() }
-    
+    elements <- .check_elements(x = elements, default = initializeCHNOPS())
+
     # If only a single mass is given, intensities are irrelevant
     if (length(masses) == 1) { intensities <- 1 }
     
     if (length(masses) != length(intensities)) { stop("masses and intensities have different lengths!") }
     
     # Calculate (average) mass difference, guess charge and recalculate
-    charge <- 1
-    
+    # ToDo: we could calculate the absolute number of charges for typical CHNOPS compounds using
+    # z <- which.min(median(diff(masses))-1/1:5)
+    # however, we can not determine positive or negative ionization this way
+
     .check_maxisotopes(maxisotopes)
     
-    # Remember ordering of element names, but ensure list of elements is ordered by mass
+    # Remember ordering of element names (for Formula output), but ensure list of elements is ordered by mass
     element_order <- sapply(elements, function(x) { x$name })
     elements <- elements[order(sapply(elements, function(x) { x$mass }))]
     
     # Calculate relative Error based on masses[1] and mzabs
     ppm <- ppm + mzabs / masses[1] * 1000000
   
+    minElements <- .check_limElements(minElements, elements, default = 0)
+    maxElements <- .check_limElements(maxElements, elements, default = 999)
+    
     # Finally ready to make the call...
     # 20241106: de-couple 'intensities' from the calling environment using c(intensities) to solve issue #21
     .Call(

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,3 +72,83 @@
     x <- names(.CountChemicalElements(fml))
     return(initializeElements(x))
 }
+
+#' @title .check_elements
+#' @description \code{.check_elements} will check this parameter in various
+#'     functions to ensure that it is within the specifications. It also allows
+#'     the user to provide the element definitions via the legacy way (as a list
+#'     similar to the initializeElements() output) or similar to the way the 
+#'     parameters `minElements`and `maxElements` are defined (character).
+#' @param x elements parameter.
+#' @param default A default valid element set.
+#' @return Either the default set or a correct elemental set based on x.
+#' @examples
+#' .check_elements(x = NULL)
+#' .check_elements(x = "CHNOPS")
+#' .check_elements(x = "NA")
+#' .check_elements(x = "Na")
+#' .check_elements(x = "AllWrong")
+#' .check_elements(x = initializeElements(c("C","H","N")))
+#' 
+#' @noRd
+#' @keywords internal
+.check_elements <- function(x = NULL, default = initializePSE()) {
+    # return default element set (PSE if not defined otherwise) for x = NULL
+    if (is.null(x)) return(default)
+    
+    # extract valid element name if x is a character vector of length = 1 and return their definitions
+    if (length(x)==1 & is.character(x)) {
+        ele <- names(.CountChemicalElements(x))
+        PSE <- initializePSE()
+        nms <- sapply(PSE, function(x) { x$name })
+        idx <- !(ele %in% nms)
+        if (any(idx)) {
+            warning("Could not find a definition for element", ifelse(sum(idx)>=2, "s ", " "), paste(ele[idx], collapse = ", "))
+        }
+        if (any(!idx)) {
+            return(PSE[nms %in% ele])
+        } else {
+            return(default)
+        }
+    }
+    
+    # return default element set (PSE if not defined otherwise) for x = anything else but a list
+    if (!is.list(x) || length(x) == 0) {
+        return(default)
+    } else {
+        # return the original input as it seems to be ok
+        return(x)
+    }
+}
+
+#' @title .check_limElements
+#' @description \code{.check_limElements} will check elemental limit parameters 
+#'     `minElements`and `maxElements` to ensure that they are within the 
+#'     specifications.
+#' @param x limit parameter.
+#' @param elements A valid element list.
+#' @param default A default value to be used as a limit.
+#' @return Either the input or stops with an error message.
+#' @examples
+#' .check_limElements(x = "C0", elements = initializeElements("Na"))
+#' .check_limElements(x = "CHNOPS")
+#' 
+#' @noRd
+#' @keywords internal
+.check_limElements <- function(x = NULL, elements = initializePSE(), default = 1) {
+    ele <- .CountChemicalElements(x)
+    nms <- sapply(elements, function(x) { x$name })
+    idx <- !(names(ele) %in% nms)
+    if (any(idx)) {
+        # elements with limit specifications but which are not present in the defined element set should be removed
+        warning("Removed element", ifelse(sum(idx)>=2, "s ", " "), paste(names(ele[idx]), collapse = ", "), " from input ", x)
+    }
+    if (any(!idx)) {
+        # filter original definition for allowed elements
+        x <- paste(names(ele[!idx]), ele[!idx], sep = "", collapse="")
+    } else {
+        # provide a vector based on the element set
+        x <- paste(nms, default, sep = "", collapse="")
+    }
+    return(x)
+}

--- a/man/decomposeIsotopes.Rd
+++ b/man/decomposeIsotopes.Rd
@@ -42,7 +42,11 @@ isotopeScore(molecule, masses, intensities)
 
 \item{mzabs}{Absolute deviation in Dalton (mzabs and ppm will be added).}
 
-\item{elements}{List of allowed chemical elements, defaults to CHNOPS. See \code{\link{initializeElements}}.}
+\item{elements}{List of allowed chemical elements, defaults to CHNOPS. 
+See \code{\link{initializeElements}}. Can also be specified similar to
+parameter `minElements` like a formula. 'CHNOPS' would define the elements
+C, H, N, O, P and S. 'NA' would specify the element N and return a warning
+regarding 'A' because this element is undefined in the PSE.}
 
 \item{filter}{NYI, will be a selection of DU, DBE and Nitrogen rules.}
 

--- a/tests/testthat/test-decomposeIsotopes.R
+++ b/tests/testthat/test-decomposeIsotopes.R
@@ -13,8 +13,14 @@ testthat::test_that(
 testthat::test_that(
     desc = "decomposeIsotopes can handle element list without Carbon", 
     code = {
-        # $JL$ this should NOT return an error but currently does
-        testthat::expect_error(decomposeIsotopes(masses = 14.003, intensities = 1, elements = initializeElements("N")))
+        # this should return two warnings from v1.67.6 on
+        # reason is the default parameter of 'minElements' = C0 in decomposeIsotopes()
+        # --> this caused errors if parameter 'elements' did not specify C
+        testthat::expect_warning(
+            testthat::expect_warning(
+                decomposeIsotopes(masses = 14.003, intensities = 1, elements = initializeElements("N"))
+            )
+        )
     }
 )
 

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,0 +1,2 @@
+Rdisop.html
+Rdisop.R

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,2 +1,0 @@
-Rdisop.html
-Rdisop.R


### PR DESCRIPTION
2025-05-27 Jan Lisec <jan.lisec@bam.de>

    * Rdisop-1.67.6
    * parameter `elements` can now be specified using a character like 'CHNOPS' 
      similar to the parameters `minElements` and `maxElements`
    * fix for issue #5; implementing checks for parameters `minElements` and 
      `maxElements` (both have default settings including element 'C' which 
      caused an error when C was not included in the defined element list)
    * implementing checks for parameter `elements` using internal function
      `check_elements()`